### PR TITLE
修复火狐浏览器下一个图片覆盖右边菜单的问题

### DIFF
--- a/source/static/css/style.css.sass
+++ b/source/static/css/style.css.sass
@@ -58,7 +58,7 @@ dl.horizontal-wide
   font-size: 95%
 
 img.center
-  display: block
+  display: table-caption
   margin: 0 auto
 
 .navbox


### PR DESCRIPTION
比如说Aegisub选项这个页面
